### PR TITLE
build.sh: nitpicks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,10 +9,8 @@ git clone https://github.com/StyraInc/highlightjs-rego.git build/highlightjs-reg
 
 ln -s "${PWD}"/build/highlightjs-rego build/highlight.js/extra/highlightjs-rego
 
-(
-    cd build/highlight.js &&
-    npm install &&
-    node ./tools/build.js -t cdn &&
-    cd ../.. &&
-    cp -r build/highlightjs-rego/dist ./
-)
+cd build/highlight.js
+npm ci
+node ./tools/build.js -t cdn
+cd ../..
+cp -r build/highlightjs-rego/dist ./


### PR DESCRIPTION
1. `npm ci` is better than `npm install`, the former takes package-lock.json into account. `npm install` could pick other versions.
2. Since we already `set -e`, i.e., exit the script if any command exits with an non-zero exit code, I think the last calls can be simplified.