### PR TITLE
releng: bring npm and github release in sync

### DIFF
--- a/.changeset/ten-pens-melt.md
+++ b/.changeset/ten-pens-melt.md
@@ -1,0 +1,12 @@
+---
+"@styra/highlightjs-rego": patch
+---
+
+synchronize release toolinig
+
+We've switched to using changesets for the release management
+of this package. Since the tag "v0.1.0" had already existed,
+the github release wasn't updated. This change should bring
+Github Release and NPM version in sync again.
+
+There is no change to the syntax highlighting code.


### PR DESCRIPTION
Created the changeset with:
- `npm i`
- `npx changeset`
- edit `.changeset/*.md`
- commit that md file