### PR TITLE
build: split in two scripts

### DIFF
--- a/.changeset/mean-knives-remember.md
+++ b/.changeset/mean-knives-remember.md
@@ -1,0 +1,5 @@
+---
+"@styra/highlightjs-rego": patch
+---
+
+attempt two to fix build scripts and github publishing

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "src"
   ],
   "scripts": {
-    "publish": "./build.sh && npx changeset publish"
+    "build": "./build.sh",
+    "publish": "npm run build && changeset publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For some reason, what works in our other repos fails here. Trying to minimise the differences 🔍 